### PR TITLE
Merge Layered Finite Difference Solver

### DIFF
--- a/src/fdtd.hpp
+++ b/src/fdtd.hpp
@@ -76,7 +76,7 @@ using namespace std;
 
 // Disable layered FDTD code (comment out if you want to test layered FDTD)
 #define SKIP_WRITE_SYS_TO_FILE        // Skip writing sys obj to txt files
-#define SKIP_LAYERED_FDTD             // Skip the main function to call layeredFdtd code
+#define SKIP_LAYERED_FDTD             // Skip the main function's calling layeredFdtd code
 
 // Function-like macros
 #define NELEMENT(x) ((sizeof x) / (sizeof x[0]))
@@ -4093,7 +4093,7 @@ public:
     /* Construct Z parameters with V0 and Vh */
     void Construct_Z_V0_Vh(complex<double> *x, int freqNo, int sourcePort){
 
-        /* x: field distribution
+        /* x: field distribution ({e}_PEC has been removed in this *x)
         freqNo: frequency no.
         sourcePort: port no.
         Note: portDirection is the relative position of the port to the ground. E.g., ground is on the top, then portDirection = -1 */
@@ -4417,5 +4417,5 @@ int matrix_multi(char operation, lapack_complex_double *a, myint arow, myint aco
 int reference(fdtdMesh *sys, int freqNo, myint *RowId, myint *ColId, double *val);
 int plotTime(fdtdMesh *sys, int sourcePort, double *u0d, double *u0c);
 int avg_length(fdtdMesh *sys, int iz, int iy, int ix, double &lx, double &ly, double &lz);
-vector<myint> Map_eInd_GrowZ2Y(const myint Nx, const myint Ny, const myint Nz);
+vector<myint> map_eIndexFromGrowzToGrowy(const myint Nx, const myint Ny, const myint Nz);
 #endif

--- a/src/fdtd.hpp
+++ b/src/fdtd.hpp
@@ -33,14 +33,6 @@ typedef long long int myint;
 typedef int myint;
 #endif
 
-// Customize the complex type in MKL and LAPACK to std::complex<double>
-#include "mkl_types.h"
-#define MKL_Complex16 std::complex<double>
-#ifndef LAPACK_COMPLEX_CUSTOM
-#define LAPACK_COMPLEX_CUSTOM
-#define lapack_complex_double std::complex<double>
-#endif
-
 #include <mkl.h>
 #include <mkl_spblas.h>
 
@@ -3779,10 +3771,10 @@ public:
                     //out << vr[temp * n + i] << " " << -vr[(temp + 1) * n + i] << " ";
                     //if (i == 0)
                     //    cout << wrc[j] << " " << wic[j] << endl;
-                    v[temp * n + i].real(vr[temp * n + i]);
-                    v[temp * n + i].imag(vr[(temp + 1) * n + i]);
-                    v[(temp + 1) * n + i].real(vr[temp * n + i]);
-                    v[(temp + 1) * n + i].imag(-vr[(temp + 1) * n + i]);
+                    v[temp * n + i].real = vr[temp * n + i];
+                    v[temp * n + i].imag = vr[(temp + 1) * n + i];
+                    v[(temp + 1) * n + i].real = vr[temp * n + i];
+                    v[(temp + 1) * n + i].imag = -vr[(temp + 1) * n + i];
                     temp++;
                     temp++;
                     j++;
@@ -3809,9 +3801,11 @@ public:
         this->Vh = new lapack_complex_double[(this->N_edge - this->bden) * mm];
         for (i = 0; i < mm; i++){
             for (j = 0; j < (this->N_edge - this->bden); j++){
-                this->Vh[i * (this->N_edge - this->bden) + j] = 0;
+                this->Vh[i * (this->N_edge - this->bden) + j].real = 0;
+                this->Vh[i * (this->N_edge - this->bden) + j].imag = 0;
                 for (int in = 0; in < k; in++){
-                    this->Vh[i * (this->N_edge - this->bden) + j] += V[in * (this->N_edge - this->bden) * 2 + j] * v[i * k + in];
+                    this->Vh[i * (this->N_edge - this->bden) + j].real += V[in * (this->N_edge - this->bden) * 2 + j] * v[i * k + in].real;
+                    this->Vh[i * (this->N_edge - this->bden) + j].imag += V[in * (this->N_edge - this->bden) * 2 + j] * v[i * k + in].imag;
                 }
             }
         }
@@ -3895,10 +3889,10 @@ public:
         while (indi < n) {
             if (abs(alphai[indi] / beta[indi]) > eps && abs(alphar[indi] / beta[indi]) < 1) {    // the eigenvalue should have a small real part and a non-zero imaginary part
                 for (int indk = 0; indk < this->N_edge - this->bden; indk++) {
-                    this->Vh[indj * (this->N_edge - this->bden) + indk].real(vr[indi * (this->N_edge - this->bden) * 2 + indk]);
-                    this->Vh[indj * (this->N_edge - this->bden) + indk].imag(vr[(indi + 1) * (this->N_edge - this->bden) * 2 + indk]);
-                    this->Vh[(indj + 1) * (this->N_edge - this->bden) + indk].real(vr[indi * (this->N_edge - this->bden) * 2 + indk]);
-                    this->Vh[(indj + 1) * (this->N_edge - this->bden) + indk].imag(-vr[(indi + 1) * (this->N_edge - this->bden) * 2 + indk]);
+                    this->Vh[indj * (this->N_edge - this->bden) + indk].real = vr[indi * (this->N_edge - this->bden) * 2 + indk];
+                    this->Vh[indj * (this->N_edge - this->bden) + indk].imag = vr[(indi + 1) * (this->N_edge - this->bden) * 2 + indk];
+                    this->Vh[(indj + 1) * (this->N_edge - this->bden) + indk].real = vr[indi * (this->N_edge - this->bden) * 2 + indk];
+                    this->Vh[(indj + 1) * (this->N_edge - this->bden) + indk].imag = -vr[(indi + 1) * (this->N_edge - this->bden) * 2 + indk];
                 }
                 indj++;
                 indj++;
@@ -3908,7 +3902,7 @@ public:
         }
         for (indi = 0; indi < this->N_edge - this->bden; indi++) {
             for (indj = 0; indj < this->leng_Vh; indj++) {
-                out << this->Vh[indj * (this->N_edge - this->bden) + indi].real() << " " << this->Vh[indj * (this->N_edge - this->bden) + indi].imag() << " ";
+                out << this->Vh[indj * (this->N_edge - this->bden) + indi].real << " " << this->Vh[indj * (this->N_edge - this->bden) + indi].imag << " ";
             }
             out << endl;
         }

--- a/src/fdtd.hpp
+++ b/src/fdtd.hpp
@@ -32,6 +32,15 @@ typedef long long int myint;
 #else
 typedef int myint;
 #endif
+
+// Customize the complex type in MKL and LAPACK to std::complex<double>
+#include "mkl_types.h"
+#define MKL_Complex16 std::complex<double>
+#ifndef LAPACK_COMPLEX_CUSTOM
+#define LAPACK_COMPLEX_CUSTOM
+#define lapack_complex_double std::complex<double>
+#endif
+
 #include <mkl.h>
 #include <mkl_spblas.h>
 
@@ -3770,10 +3779,10 @@ public:
                     //out << vr[temp * n + i] << " " << -vr[(temp + 1) * n + i] << " ";
                     //if (i == 0)
                     //    cout << wrc[j] << " " << wic[j] << endl;
-                    v[temp * n + i].real = vr[temp * n + i];
-                    v[temp * n + i].imag = vr[(temp + 1) * n + i];
-                    v[(temp + 1) * n + i].real = vr[temp * n + i];
-                    v[(temp + 1) * n + i].imag = -vr[(temp + 1) * n + i];
+                    v[temp * n + i].real(vr[temp * n + i]);
+                    v[temp * n + i].imag(vr[(temp + 1) * n + i]);
+                    v[(temp + 1) * n + i].real(vr[temp * n + i]);
+                    v[(temp + 1) * n + i].imag(-vr[(temp + 1) * n + i]);
                     temp++;
                     temp++;
                     j++;
@@ -3800,11 +3809,9 @@ public:
         this->Vh = new lapack_complex_double[(this->N_edge - this->bden) * mm];
         for (i = 0; i < mm; i++){
             for (j = 0; j < (this->N_edge - this->bden); j++){
-                this->Vh[i * (this->N_edge - this->bden) + j].real = 0;
-                this->Vh[i * (this->N_edge - this->bden) + j].imag = 0;
+                this->Vh[i * (this->N_edge - this->bden) + j] = 0;
                 for (int in = 0; in < k; in++){
-                    this->Vh[i * (this->N_edge - this->bden) + j].real += V[in * (this->N_edge - this->bden) * 2 + j] * v[i * k + in].real;
-                    this->Vh[i * (this->N_edge - this->bden) + j].imag += V[in * (this->N_edge - this->bden) * 2 + j] * v[i * k + in].imag;
+                    this->Vh[i * (this->N_edge - this->bden) + j] += V[in * (this->N_edge - this->bden) * 2 + j] * v[i * k + in];
                 }
             }
         }
@@ -3888,10 +3895,10 @@ public:
         while (indi < n) {
             if (abs(alphai[indi] / beta[indi]) > eps && abs(alphar[indi] / beta[indi]) < 1) {    // the eigenvalue should have a small real part and a non-zero imaginary part
                 for (int indk = 0; indk < this->N_edge - this->bden; indk++) {
-                    this->Vh[indj * (this->N_edge - this->bden) + indk].real = vr[indi * (this->N_edge - this->bden) * 2 + indk];
-                    this->Vh[indj * (this->N_edge - this->bden) + indk].imag = vr[(indi + 1) * (this->N_edge - this->bden) * 2 + indk];
-                    this->Vh[(indj + 1) * (this->N_edge - this->bden) + indk].real = vr[indi * (this->N_edge - this->bden) * 2 + indk];
-                    this->Vh[(indj + 1) * (this->N_edge - this->bden) + indk].imag = -vr[(indi + 1) * (this->N_edge - this->bden) * 2 + indk];
+                    this->Vh[indj * (this->N_edge - this->bden) + indk].real(vr[indi * (this->N_edge - this->bden) * 2 + indk]);
+                    this->Vh[indj * (this->N_edge - this->bden) + indk].imag(vr[(indi + 1) * (this->N_edge - this->bden) * 2 + indk]);
+                    this->Vh[(indj + 1) * (this->N_edge - this->bden) + indk].real(vr[indi * (this->N_edge - this->bden) * 2 + indk]);
+                    this->Vh[(indj + 1) * (this->N_edge - this->bden) + indk].imag(-vr[(indi + 1) * (this->N_edge - this->bden) * 2 + indk]);
                 }
                 indj++;
                 indj++;
@@ -3901,7 +3908,7 @@ public:
         }
         for (indi = 0; indi < this->N_edge - this->bden; indi++) {
             for (indj = 0; indj < this->leng_Vh; indj++) {
-                out << this->Vh[indj * (this->N_edge - this->bden) + indi].real << " " << this->Vh[indj * (this->N_edge - this->bden) + indi].imag << " ";
+                out << this->Vh[indj * (this->N_edge - this->bden) + indi].real() << " " << this->Vh[indj * (this->N_edge - this->bden) + indi].imag() << " ";
             }
             out << endl;
         }

--- a/src/fdtd.hpp
+++ b/src/fdtd.hpp
@@ -4417,5 +4417,4 @@ int matrix_multi(char operation, lapack_complex_double *a, myint arow, myint aco
 int reference(fdtdMesh *sys, int freqNo, myint *RowId, myint *ColId, double *val);
 int plotTime(fdtdMesh *sys, int sourcePort, double *u0d, double *u0c);
 int avg_length(fdtdMesh *sys, int iz, int iy, int ix, double &lx, double &ly, double &lz);
-vector<myint> map_eIndexFromGrowzToGrowy(const myint Nx, const myint Ny, const myint Nz);
 #endif

--- a/src/generateStiff.cpp
+++ b/src/generateStiff.cpp
@@ -1010,8 +1010,8 @@ int matrix_multi_cd(char operation, lapack_complex_double *a, myint arow, myint 
         for (myint ind = 0; ind < acol; ind++) {
             for (myint ind1 = 0; ind1 < bcol; ind1++) {
                 for (myint ind2 = 0; ind2 < arow; ind2++) {
-                    tmp3[ind1 * acol + ind].real(tmp3[ind1 * acol + ind].real() + a[ind * arow + ind2].real() * b[ind1 * brow + ind2]);
-                    tmp3[ind1 * acol + ind].imag(tmp3[ind1 * acol + ind].imag() - a[ind * arow + ind2].imag() * b[ind1 * brow + ind2]);
+                    tmp3[ind1 * acol + ind].real = tmp3[ind1 * acol + ind].real + a[ind * arow + ind2].real * b[ind1 * brow + ind2];
+                    tmp3[ind1 * acol + ind].imag = tmp3[ind1 * acol + ind].imag - a[ind * arow + ind2].imag * b[ind1 * brow + ind2];
                 }
             }
         }
@@ -1020,7 +1020,8 @@ int matrix_multi_cd(char operation, lapack_complex_double *a, myint arow, myint 
         for (myint ind = 0; ind < arow; ind++) {
             for (myint ind1 = 0; ind1 < bcol; ind1++) {
                 for (myint ind2 = 0; ind2 < acol; ind2++) {
-                    tmp3[ind1 * arow + ind] = tmp3[ind1 * arow + ind] + a[ind2 * arow + ind] * b[ind1 * brow + ind2];
+                    tmp3[ind1 * arow + ind].real = tmp3[ind1 * arow + ind].real + a[ind2 * arow + ind].real * b[ind1 * brow + ind2];
+                    tmp3[ind1 * arow + ind].imag = tmp3[ind1 * arow + ind].imag + a[ind2 * arow + ind].imag * b[ind1 * brow + ind2];
                 }
             }
         }

--- a/src/generateStiff.cpp
+++ b/src/generateStiff.cpp
@@ -942,9 +942,7 @@ int mklMatrixMulti_nt(fdtdMesh *sys, myint &leng_A, myint *aRowId, myint *aColId
     ofstream out;
     //out.open("S.txt", std::ofstream::out | std::ofstream::trunc);
 
-#ifdef SKIP_LAYERED_FDTD  
-// Generate S matrix in COO format and Remove {e} at PEC BC. Layer growth along z
-
+    // Generate S matrix in COO format and Remove {e} at PEC BC. Layer growth along z
     for (myint i = 0; i < ARows; i++){
         if (sys->lbde.find(i) != sys->lbde.end() || sys->ubde.find(i) != sys->ubde.end()){   // if this row number is among the upper or lower boundary edges
             continue;
@@ -970,31 +968,6 @@ int mklMatrixMulti_nt(fdtdMesh *sys, myint &leng_A, myint *aRowId, myint *aColId
         }
         v.clear();
     }
-#else
-// Generate S matrix in COO format without removing {e} at PEC, namely 6 PMC BCs.
-// Layer growth along y.
-
-    vector<myint> eInd_map_z2y = map_eIndexFromGrowzToGrowy(sys->N_cell_x, sys->N_cell_y, sys->N_cell_z);
-
-    for (myint i = 0; i < ARows; i++) {
-        num = ArowEnd[i] - ArowStart[i];
-        count = 0;
-        vector<pair<myint, double>> v(col_val.begin() + ArowStart[i], col_val.begin() + ArowEnd[i]);
-        sort(v.begin(), v.end());
-
-        while (count < num) {
-            sys->SRowId[j] = eInd_map_z2y[i];
-            sys->SColId[j] = eInd_map_z2y[v[count].first];
-            sys->Sval[j] = v[count].second / MU;
-            //out << sys->SRowId[j] << " " << sys->SColId[j] << " ";
-            //out << sys->Sval[j] << endl;
-
-            j++;
-            count++;
-        }
-        v.clear();
-    }
-#endif
 
     //out.close();
     leng_A = j;

--- a/src/generateStiff.cpp
+++ b/src/generateStiff.cpp
@@ -1010,8 +1010,8 @@ int matrix_multi_cd(char operation, lapack_complex_double *a, myint arow, myint 
         for (myint ind = 0; ind < acol; ind++) {
             for (myint ind1 = 0; ind1 < bcol; ind1++) {
                 for (myint ind2 = 0; ind2 < arow; ind2++) {
-                    tmp3[ind1 * acol + ind].real = tmp3[ind1 * acol + ind].real + a[ind * arow + ind2].real * b[ind1 * brow + ind2];
-                    tmp3[ind1 * acol + ind].imag = tmp3[ind1 * acol + ind].imag - a[ind * arow + ind2].imag * b[ind1 * brow + ind2];
+                    tmp3[ind1 * acol + ind].real(tmp3[ind1 * acol + ind].real() + a[ind * arow + ind2].real() * b[ind1 * brow + ind2]);
+                    tmp3[ind1 * acol + ind].imag(tmp3[ind1 * acol + ind].imag() - a[ind * arow + ind2].imag() * b[ind1 * brow + ind2]);
                 }
             }
         }
@@ -1020,8 +1020,7 @@ int matrix_multi_cd(char operation, lapack_complex_double *a, myint arow, myint 
         for (myint ind = 0; ind < arow; ind++) {
             for (myint ind1 = 0; ind1 < bcol; ind1++) {
                 for (myint ind2 = 0; ind2 < acol; ind2++) {
-                    tmp3[ind1 * arow + ind].real = tmp3[ind1 * arow + ind].real + a[ind2 * arow + ind].real * b[ind1 * brow + ind2];
-                    tmp3[ind1 * arow + ind].imag = tmp3[ind1 * arow + ind].imag + a[ind2 * arow + ind].imag * b[ind1 * brow + ind2];
+                    tmp3[ind1 * arow + ind] = tmp3[ind1 * arow + ind] + a[ind2 * arow + ind] * b[ind1 * brow + ind2];
                 }
             }
         }

--- a/src/generateStiff.cpp
+++ b/src/generateStiff.cpp
@@ -585,6 +585,7 @@ int reference(fdtdMesh *sys, int freqNo, myint *RowId, myint *ColId, double *val
             for (int inde = 0; inde < sys->portCoor[sourcePort].portEdge[sourcePortSide].size(); inde++){
                 J[sourcePort * (sys->N_edge - sys->bden) + sys->mapEdge[sys->portCoor[sourcePort].portEdge[sourcePortSide][inde]]] = 
                     0. - (1i) * (double) (sys->portCoor[sourcePort].portDirection[sourcePortSide]) * freq * 2. * M_PI;
+                //cout << "SourcePort " << sourcePort << " sourcePortSide " << sourcePortSide << " is " << sys->portCoor[sourcePort].portEdge[sourcePortSide][inde] << endl;
                 //cout << "SourcePort " << sourcePort << " sourcePortSide " << sourcePortSide << " is " << sys->portCoor[sourcePort].portDirection[sourcePortSide] << endl;
 
             }
@@ -973,7 +974,7 @@ int mklMatrixMulti_nt(fdtdMesh *sys, myint &leng_A, myint *aRowId, myint *aColId
 // Generate S matrix in COO format without removing {e} at PEC, namely 6 PMC BCs.
 // Layer growth along y.
 
-    vector<myint> eInd_map_z2y = Map_eInd_GrowZ2Y(sys->N_cell_x, sys->N_cell_y, sys->N_cell_z);
+    vector<myint> eInd_map_z2y = map_eIndexFromGrowzToGrowy(sys->N_cell_x, sys->N_cell_y, sys->N_cell_z);
 
     for (myint i = 0; i < ARows; i++) {
         num = ArowEnd[i] - ArowStart[i];

--- a/src/layeredFdtd.hpp
+++ b/src/layeredFdtd.hpp
@@ -78,8 +78,8 @@ int layeredFdtd(void) {
 		return status;
 	}
 
-    Solve_E_Zpara_InPardiso_reference(&sys);
 	Solve_E_Zpara_InPardiso_layered(&sys);
+    Solve_E_Zpara_InPardiso_reference(&sys);
 
 	return 0;
 }

--- a/src/layeredFdtd.hpp
+++ b/src/layeredFdtd.hpp
@@ -18,8 +18,8 @@ int layeredFdtd(void) {
 	// Read object sys (class fdtdMesh) from files
 	ReadSysFromFile(&sys);
 
-	// Write object sys to files
-	WriteSysToFile(sys);
+	//// Write object sys to files
+	//WriteSysToFile(sys);
 
 	// Mesh the domain and mark conductors
 	unordered_set<double> portCoorx, portCoory;
@@ -78,8 +78,8 @@ int layeredFdtd(void) {
 		return status;
 	}
 
-	Solve_E_Zpara_InPardiso_layered(&sys);
-    Solve_E_Zpara_InPardiso_reference(&sys);
+    solveE_Zpara_layered(&sys);
+    solveE_Zpara_reference(&sys);
 
 	return 0;
 }

--- a/src/mapIndex.hpp
+++ b/src/mapIndex.hpp
@@ -1,0 +1,255 @@
+#ifndef GDS2PARA_MAP_INDEX_H_
+#define GDS2PARA_MAP_INDEX_H_
+
+#include "fdtd.hpp"
+//#include "matrixTypeDef.hpp"
+
+class mapIndex {
+public:
+    // num of bricks Nx*Ny*Nz
+    myint Nx, Ny, Nz;
+    myint N_totEdges;                   // number of all {e} or edges without PEC removal
+
+    // num of edges after removing PEC
+    myint N_edgesAtPEC;                 // number of {e} or edges at PEC surfaces
+    myint N_surfExEz_rmPEC;             // number of {e}_surface at one surface e.g. 0s, mode (growY, removed PEC)
+    myint N_volEy_rmPEC;                // number of {e}_volumn at one layer, e.g. 0v, mode (growY, removed PEC)
+
+    // Upper PEC edge indices (z=zmax) and lower PEC edge indices (z=zmin), index mode (growY, no PEC removal)
+    unordered_set<myint> edges_upperPEC;
+    unordered_set<myint> edges_lowerPEC;
+
+    // maps
+    vector<myint> eInd_map_z2y;         // map {e} index: (growZ, no PEC removal) -> (growY, no PEC removal)
+    vector<myint> eInd_map_y2z;         // map {e} index: (growY, no PEC removal) -> (growZ, no PEC removal)
+
+    vector<myint> eInd_map_y2rmPEC;     // map {e} index: (growY, no PEC removal) -> (growY, removed PEC)
+    vector<myint> eInd_map_rmPEC2y;     // map {e} index: (growY, removed PEC) -> (growY, no PEC removal)
+
+    // sys.mapEdge;                     // map {e} index: (growZ, no PEC removal) -> (growZ, removed PEC)
+    // sys.mapEdgeR;                    // map {e} index: (growZ, removed PEC) -> (growZ, no PEC removal)
+
+    vector<myint> eInd_map_rmPEC_z2y;   // map {e} index: (growZ, removed PEC) -> (growY, removed PEC)
+    vector<myint> eInd_map_rmPEC_y2z;   // map {e} index: (growY, removed PEC) -> (growZ, removed PEC)
+
+    // Constructor
+    mapIndex(myint Nx, myint Ny, myint Nz) {
+        this->Nx = Nx;
+        this->Ny = Ny;
+        this->Nz = Nz;
+
+        this->N_totEdges = Nx*(Ny + 1)*(Nz + 1) + (Nx + 1)*Ny*(Nz + 1) + (Nx + 1)*(Ny + 1)*Nz;
+
+        // For different PEC BCs
+        this->N_edgesAtPEC = 0;
+        this->N_surfExEz_rmPEC = Nx*(Nz + 1) + Nz*(Nx + 1);
+        this->N_volEy_rmPEC = (Nx + 1)*(Nz + 1);
+#ifdef LOWER_BOUNDARY_PEC
+        this->N_edgesAtPEC += Nx*(Ny + 1) + (Nx + 1)*Ny;    // add num of Ex & Ey at PEC surface
+        this->N_surfExEz_rmPEC -= Nx;                       // remove Ex at PEC
+        this->N_volEy_rmPEC -= (Nx + 1);                    // remove Ey at PEC
+#endif
+#ifdef UPPER_BOUNDARY_PEC
+        this->N_edgesAtPEC += Nx*(Ny + 1) + (Nx + 1)*Ny;    // add num of Ex & Ey at PEC surface
+        this->N_surfExEz_rmPEC -= Nx;                       // remove Ex at PEC
+        this->N_volEy_rmPEC -= (Nx + 1);                    // remove Ey at PEC
+#endif
+
+    }
+
+    // Set global {e} index map between mode (growZ, no PEC removal) and mode (growY, no PEC removal)
+    void setEdgeMap_growZgrowY() {
+    /*  The index follows y - x - z ordering, and {e} is stacked layer by layer as
+        {e_surface, e_volumn}.T at each layer. For the two cases here:
+        - case 1 ~ grow along Z: {e} = {e_s, | e_v}.T = {ey,ex, | ez}.T, in which vector
+                {ey} first runs through y for each x, then runs through x as by
+                y - x - z ordering. Same for {ex} ~y->x and {ez} ~y->x.
+        - case 2 ~ grow along Y: {e} = {ex,ez, | ey}.T at every layer.
+                {ex}, {ez} and {ey} ~x->z, frist all x for each z then all z
+
+        Results: 
+            - 2 index maps are stored in attributes "eInd_map_z2y" and "eInd_map_y2z"
+            - Each map is a vector of size N_e, eInd_map_?2?[oldInd] = newInd
+
+        Yee's grid is used, with E at edge center and H at face center. Outmost
+        boundaries are all E edges. Removal of {e} due to PEC BC has not been considered. */
+
+        // Num of surface or volumetric unknown e at each layer
+        myint Nx = this->Nx;
+        myint Ny = this->Ny;
+        myint Nz = this->Nz;
+
+        myint n_surfEy_growZ = Ny*(Nx + 1);
+        myint n_surfEyEx = n_surfEy_growZ + Nx*(Ny + 1);
+        myint n_volEz = (Nx + 1)*(Ny + 1);
+        myint n_layerE_growZ = n_surfEyEx + n_volEz;
+
+        myint n_surfEx_growY = Nx*(Nz + 1);
+        myint n_surfExEz = n_surfEx_growY + Nz*(Nx + 1);
+        myint n_volEy = (Nx + 1)*(Nz + 1);
+        myint n_layerE_growY = n_surfExEz + n_volEy;
+
+        myint N_tot_E = n_surfEyEx*(Nz + 1) + n_volEz*Nz;
+
+        // y - x - z ordering
+        // Grow along Z : {e} = { ey,ex, | ez }.T, y->x frist all y for each x then all x
+        // Grow along Y : {e} = { ex,ez, | ey }.T, x->z frist all x for each z then all z
+
+        // Map Grow Z to Grow Y
+        this->eInd_map_z2y.reserve(N_tot_E);
+        this->eInd_map_z2y.assign(N_tot_E, -1);
+
+        for (myint iz = 0; iz < Nz + 1; iz++) {     // Map the edges along y direction, Ey
+            for (myint iy = 0; iy < Ny; iy++) {
+                for (myint ix = 0; ix < Nx + 1; ix++) {
+                    this->eInd_map_z2y[iz*n_layerE_growZ + ix*(Ny)+iy] =
+                        iy*n_layerE_growY + n_surfExEz + iz*(Nx + 1) + ix;
+                }
+            }
+        }
+        for (myint iz = 0; iz < Nz + 1; iz++) {     // Map the edges along x direction, Ex
+            for (myint iy = 0; iy < Ny + 1; iy++) {
+                for (myint ix = 0; ix < Nx; ix++) {
+                    this->eInd_map_z2y[iz*n_layerE_growZ + n_surfEy_growZ + ix*(Ny + 1) + iy] =
+                        iy*n_layerE_growY + iz*(Nx)+ix;
+                }
+            }
+        }
+        for (myint iz = 0; iz < Nz; iz++) {         // Map the edges along z direction, Ez
+            for (myint iy = 0; iy < Ny + 1; iy++) {
+                for (myint ix = 0; ix < Nx + 1; ix++) {
+                    this->eInd_map_z2y[iz*n_layerE_growZ + n_surfEyEx + ix*(Ny + 1) + iy] =
+                        iy*n_layerE_growY + n_surfEx_growY + iz*(Nx + 1) + ix;
+                }
+            }
+        }
+
+        // Map Grow Y to Grow Z
+        this->eInd_map_y2z.reserve(N_tot_E);
+        this->eInd_map_y2z.assign(N_tot_E, -1);
+        for (myint id = 0; id < N_tot_E; id++) {
+            this->eInd_map_y2z[this->eInd_map_z2y[id]] = id;
+        }
+    }
+
+    // Set global {e} index map between mode (growY, no PEC removal) and (growY, removed PEC)
+    void setEdgeMap_growYremovePEC(const set<myint> &ubde, const set<myint> &lbde, myint bden) {
+    /*  Inputs:
+            - ubde = sys.ubde: upper PEC edge indices (z=zmax) with index mode (growZ, no PEC removal)
+            - lbde = sys.lbde: lower PEC edge indices (z=zmin) with index mode (growZ, no PEC removal)
+            - bden = sys.bden: number of PEC edges that was counted at meshing stage
+        Results:
+            - PEC edge indices of mode (growY, no PEC removal) stored in attributes "edges_upperPEC" & "edges_lowerPEC"
+            - 2 index maps are stored in attributes "eInd_map_y2rmPEC" and "eInd_map_rmPEC2y"       */
+
+        if (this->eInd_map_z2y.size() == 0) {
+            cout << "Failure! Run function setEdgeMap_growZgrowY() first." << endl;
+            exit(2);
+        }
+        if (this->N_edgesAtPEC != bden) {
+            cout << "Failure at mapping PEC removal! Inconsistent PEC edges." << endl <<
+                "Try to comment out code: sys->findBoundNodeEdge(inx, iny, inz); at mesh.cpp " << endl;
+            exit(2);
+        }
+
+        // Map the PEC edge indices from (growZ, no PEC removal) to (growY, no PEC removal)
+        for (auto eInd_growZ : ubde) {
+            myint eInd_growY = this->eInd_map_z2y[eInd_growZ];
+            this->edges_upperPEC.insert(eInd_growY);
+        }
+        for (auto eInd_growZ : lbde) {
+            myint eInd_growY = this->eInd_map_z2y[eInd_growZ];
+            this->edges_lowerPEC.insert(eInd_growY);
+        }
+
+        // Map mode (growY, no PEC removal) and (growY, removed PEC)
+        this->eInd_map_y2rmPEC.reserve(this->N_totEdges);
+        this->eInd_map_y2rmPEC.assign(this->N_totEdges, -1);        // removed PEC edges will be mapped to index -1
+        this->eInd_map_rmPEC2y.reserve(this->N_totEdges - this->N_edgesAtPEC);
+        this->eInd_map_rmPEC2y.assign(this->N_totEdges - this->N_edgesAtPEC, -1);
+        
+        myint count_edgesAtPEC = 0;                                 // number of identified PEC edges
+        for (myint eInd = 0; eInd < this->N_totEdges; eInd++) {     // from smallest edge index in mode (growY, no PEC removal)
+            bool edgeIsAtUpperPEC = this->edges_upperPEC.find(eInd) != this->edges_upperPEC.end();
+            bool edgeIsAtLowerPEC = this->edges_lowerPEC.find(eInd) != this->edges_lowerPEC.end();
+            if (edgeIsAtUpperPEC || edgeIsAtLowerPEC) {             // if this edge is at upper or lower PEC boundary
+                count_edgesAtPEC++;
+            }
+            else {
+                this->eInd_map_y2rmPEC[eInd] = eInd - count_edgesAtPEC;
+                this->eInd_map_rmPEC2y[eInd - count_edgesAtPEC] = eInd;
+            }
+        }
+
+    }
+
+    // Set global {e} index map between mode (growZ, removed PEC) and (growY, removed PEC)
+    void setEdgeMap_rmPEC_growZgrowY(myint *eInd_map_rmPEC2z) {
+    /*  Inputs:
+            - eInd_map_rmPEC2z = sys.mapEdgeR: map {e} index from (growZ, removed PEC) to (growZ, no PEC removal)
+        Results:
+            - 2 index maps are stored in attributes "eInd_map_rmPEC_z2y" and "eInd_map_rmPEC_y2z"       */
+
+        if (this->eInd_map_y2rmPEC.size() == 0) {
+            cout << "Failure! Run function setEdgeMap_growYremovePEC first." << endl;
+            exit(2);
+        }
+
+        // Map mode (growZ, removed PEC) and (growY, removed PEC)
+        myint N_edgesNotAtPEC = this->N_totEdges - this->N_edgesAtPEC;
+        this->eInd_map_rmPEC_z2y.reserve(N_edgesNotAtPEC);
+        this->eInd_map_rmPEC_z2y.assign(N_edgesNotAtPEC, -1);
+        this->eInd_map_rmPEC_y2z.reserve(N_edgesNotAtPEC);
+        this->eInd_map_rmPEC_y2z.assign(N_edgesNotAtPEC, -1);
+
+        for (myint eInd_rmPECz = 0; eInd_rmPECz < N_edgesNotAtPEC; eInd_rmPECz++) { // (growZ, removed PEC)
+            myint eInd_z = eInd_map_rmPEC2z[eInd_rmPECz];                           // -> (growZ, no PEC removal)
+            myint eInd_y = this->eInd_map_z2y[eInd_z];                              // -> (growY, no PEC removal)
+            myint eInd_rmPECy = this->eInd_map_y2rmPEC[eInd_y];                     // -> (growY, removed PEC)
+            this->eInd_map_rmPEC_z2y[eInd_rmPECz] = eInd_rmPECy;                    // (growZ, removed PEC) -> (growY, removed PEC)
+            this->eInd_map_rmPEC_y2z[eInd_rmPECy] = eInd_rmPECz;                    // (growY, removed PEC) -> (growZ, removed PEC)
+        }
+    }
+
+    // Map a (Block_rowId, Block_colId) pair to one unique Block index
+    myint mapBlockRowColToBlockInd(myint B_rowId, myint B_colId) const {
+    /*  Explanation to notations here:
+
+        Matrix S is partitioned into blocks as surface-vol-surface-... along row (col)
+            - Bolck ordering:     0s,0v,1s,1v,..., Nlayer_s
+            - B_rowId or B_colId: 0, 1, 2, 3, ..., 2*Nlayer
+            - Retrun BlockId:     counted nnz block Id, row major.
+
+        Example: (Nlayer = 3, Nblock = 8*Nlayer + 1 = 25)
+                          0s  0v  1s  1v  2s  2v  3s
+            B_colId->     0   1   2   3   4   5   6
+                                                        B_rowId (below)
+            BlockId:    | 0   1   2                  |    0   0s
+                        | 3   4   5                  |    1   0v
+                        | 6   7   8   9   10         |    2   1s
+                        |         11  12  13         |    3   1v
+                        |         14  15  16  17  18 |    4   2s
+                        |                 19  20  21 |    5   2v
+                        |                 22  23  24 |    6   3s        */
+
+        myint BlockId = 0;
+        myint layerId = B_rowId / 2;
+        myint isVol = B_rowId % 2;
+
+        if (layerId == 0) {     // B_rowId ~ 0s, 0v
+            BlockId = B_rowId * 3 + B_colId;
+        }
+        else if (isVol == 1) {  // The B_row is n-v
+            BlockId = 6 * layerId + B_colId + 3;
+        }
+        else {                  // The B_row is n-s
+            BlockId = 6 * layerId + B_colId;
+        }
+
+        return BlockId;
+    }
+};
+
+
+
+#endif

--- a/src/matrixTypeDef.hpp
+++ b/src/matrixTypeDef.hpp
@@ -140,11 +140,11 @@ public:
             ipiv.data()                                 // pivot indices
         );
         if (info != 0) {
-            cout << "Issue on LU factorization, LAPACKE_dgetrf returns: " << info << endl;
+            cout << "Issue on LU factorization, LAPACKE_?getrf returns: " << info << endl;
             exit(2);
         }
 
-        // Solve C = A_LU \ B with LAPACKE_dgetrs
+        // Solve C = A_LU \ B with LAPACKE_?getrs
         vector<MKL_Complex16> C_mklComplex(B.matrixSize);
         B.copyToMKL_Complex16(C_mklComplex.data());     // copy matrix B to a MKL_Complex16 type C_mklComplex
         info = LAPACKE_zgetrs(LAPACK_COL_MAJOR, 'N',
@@ -154,7 +154,7 @@ public:
             C_mklComplex.data(), B.N_rows               // C (copied B) will be overwritten by the solution matrix
         );
         if (info != 0) {
-            cout << "Issue on mkl backslash, LAPACKE_dgetrs returns: " << info << endl;
+            cout << "Issue on mkl backslash, LAPACKE_?getrs returns: " << info << endl;
             exit(2);
         }
 

--- a/src/matrixTypeDef.hpp
+++ b/src/matrixTypeDef.hpp
@@ -1,0 +1,207 @@
+#ifndef GDS2PARA_MATRIX_TYPEDEF_H_
+#define GDS2PARA_MATRIX_TYPEDEF_H_
+
+#include "fdtd.hpp"
+
+typedef vector< tuple<myint, myint, double> > BlockType;    // store rows-cols-vals of each block matrix
+
+// 0-based row-major 3-array CSR format of a matrix
+class csrFormatOfMatrix {
+public:
+    // matrix information
+    myint N_rows;
+    myint N_cols;
+    myint N_nnz;
+    myint *rows = nullptr;      // CSR row indices, size = N_rows + 1
+    myint *cols = nullptr;      // CSR col indices, size = N_nnz
+    double *vals = nullptr;      // CSR nnz values,  size = N_nnz
+
+                                 // Constructor
+    csrFormatOfMatrix(myint N_rows, myint N_cols, myint N_nnz) {
+        /* Inputs:
+        N_rows*N_cols:  matrix size;
+        N_nnz:          num of nonzeros.     */
+
+        this->N_rows = N_rows;
+        this->N_cols = N_cols;
+        this->N_nnz = N_nnz;
+
+        this->rows = new myint[N_rows + 1]();
+        this->cols = new myint[N_nnz]();
+        this->vals = new double[N_nnz]();
+    }
+
+    // Destructor
+    ~csrFormatOfMatrix() {
+        delete[] this->rows;
+        delete[] this->cols;
+        delete[] this->vals;
+    }
+
+    // Declaration of functions
+    int convertBlockTypeToCsr(const BlockType &block);
+};
+
+int csrFormatOfMatrix::convertBlockTypeToCsr(const BlockType &block) {
+    /* This function convert BlockType (COO) to CSR format.
+    The input BlockType must have been sorted by row index. */
+
+    // The first index of rows is always 0 and the last is always N_nnz
+    this->rows[0] = 0;
+    this->rows[this->N_rows] = block.size();
+
+    myint nnz_ind = 0;
+    myint thisRow_ind = 0;
+    for (const auto &nnz_tuple : block) {
+
+        // cols and vals are direct copy of the tuple for every nnz
+        this->cols[nnz_ind] = get<1>(nnz_tuple);
+        this->vals[nnz_ind] = get<2>(nnz_tuple);
+
+        // When saw nnz at a new row
+        while (thisRow_ind < get<0>(nnz_tuple)) {
+            thisRow_ind++;
+            this->rows[thisRow_ind] = nnz_ind;
+        }
+
+        nnz_ind++;
+
+        // Extrame case: when the last few rows are all blank
+        while (nnz_ind == block.size() && thisRow_ind < this->N_rows - 1) {
+            thisRow_ind++;
+            this->rows[thisRow_ind] = nnz_ind;
+        }
+    }
+
+    return 0;
+}
+
+// 0-based column-major dense format of a matrix stored col by col in 1-D vector
+class denseFormatOfMatrix {
+public:
+    // matrix information
+    myint N_rows;
+    myint N_cols;
+    myint matrixSize;
+    vector<double> vals;
+
+    // Constructor
+    denseFormatOfMatrix(myint N_rows, myint N_cols) {
+        this->N_rows = N_rows;
+        this->N_cols = N_cols;
+        this->matrixSize = N_rows * N_cols;
+
+        this->vals.reserve(this->matrixSize);
+        this->vals.assign(this->matrixSize, 0.0);
+    }
+
+    // Convert BlockType (COO) to dense format.
+    void convertBlockTypeToDense(const BlockType &block) {
+        for (const auto &nnz_tuple : block) {
+            myint row_ind = get<0>(nnz_tuple);
+            myint col_ind = get<1>(nnz_tuple);
+            myint ind_inArray = col_ind * this->N_rows + row_ind;
+            this->vals[ind_inArray] = get<2>(nnz_tuple);
+        }
+    }
+
+    // C = A (this) + B
+    denseFormatOfMatrix add(const denseFormatOfMatrix &B) const {
+        if (this->N_rows != B.N_rows && this->N_cols != B.N_cols) {
+            cout << "Failure to add matrices, dimensions not match!" << endl;
+            exit(2);
+        }
+
+        denseFormatOfMatrix C(this->N_rows, this->N_cols);
+        for (myint ind = 0; ind < this->matrixSize; ind++) {
+            C.vals[ind] = this->vals[ind] + B.vals[ind];
+        }
+        return C;
+    }
+
+    // C = A (this) - B
+    denseFormatOfMatrix minus(const denseFormatOfMatrix &B) {
+        if (this->N_rows != B.N_rows && this->N_cols != B.N_cols) {
+            cout << "Failure to minus matrice, dimensions not match!" << endl;
+            exit(2);
+        }
+
+        denseFormatOfMatrix C(this->N_rows, this->N_cols);
+        for (myint ind = 0; ind < this->matrixSize; ind++) {
+            C.vals[ind] = this->vals[ind] - B.vals[ind];
+        }
+        return C;
+    }
+
+    // C = A (this) * scalar
+    denseFormatOfMatrix multiplyScalar(double scalar) {
+        denseFormatOfMatrix C(this->N_rows, this->N_cols);
+        for (myint ind = 0; ind < this->matrixSize; ind++) {
+            C.vals[ind] = this->vals[ind] * scalar;
+        }
+        return C;
+    }
+
+    // C = A (this) dot B (matrix-matrix dot multiply, not element-wise multiply)
+    denseFormatOfMatrix dot(const denseFormatOfMatrix &B) {
+        if (this->N_cols != B.N_rows) {
+            cout << "Failure to dot multiply matrices, dimensions not match!" << endl;
+            exit(2);
+        }
+
+        // Use mkl cblas_?gemm (C := alpha*op(A)*op(B) + beta*C) to get C=A*B
+        denseFormatOfMatrix C(this->N_rows, B.N_cols);
+        cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans,
+            this->N_rows, B.N_cols, this->N_cols,       // matrix dimensions ~ m, n, k
+            1.0,                                        // alpha
+            this->vals.data(), this->N_rows,            // A
+            B.vals.data(), this->N_cols,                // B
+            0.0,                                        // beta
+            C.vals.data(), this->N_rows);               // C
+        return C;
+    }
+
+    // C = A (this) \ B = inv(A) dot B
+    denseFormatOfMatrix backslash(const denseFormatOfMatrix &B) {
+        if (this->N_rows != this->N_cols) {
+            cout << "Failure, matrix is not invertable!" << endl;
+            exit(2);
+        }
+        if (this->N_cols != B.N_rows) {
+            cout << "Failure to backslash matrices, dimensions not match!" << endl;
+            exit(2);
+        }
+
+        // Compute the LU factorization of a general m-by-n matrix A (this) and store in A_LU
+        vector<double> A_LU(this->vals);
+        vector<myint> ipiv(this->N_rows);
+        lapack_int info = LAPACKE_dgetrf(LAPACK_COL_MAJOR,
+            this->N_rows, this->N_cols,     // matrix dimensions ~ m, n
+            A_LU.data(),                    // matrix A
+            this->N_rows,
+            ipiv.data()                     // pivot indices
+        );
+        if (info != 0) {
+            cout << "Issue on LU factorization, LAPACKE_dgetrf returns: " << info << endl;
+            exit(2);
+        }
+
+        // Solve C = A_LU \ B with LAPACKE_dgetrs
+        denseFormatOfMatrix C(B.N_rows, B.N_cols);
+        C.vals = B.vals;                // copy matrix B to C
+        info = LAPACKE_dgetrs(LAPACK_COL_MAJOR, 'N',
+            B.N_rows, B.N_cols,         // n & nrhs
+            A_LU.data(), B.N_rows,      // A_LU
+            ipiv.data(),                // pivot indices of A_LU
+            C.vals.data(), B.N_rows     // C (copied B) will be overwritten by the solution matrix
+        );
+        if (info != 0) {
+            cout << "Issue on mkl backslash, LAPACKE_dgetrs returns: " << info << endl;
+            exit(2);
+        }
+
+        return C;
+    }
+};
+
+#endif

--- a/src/matrixTypeDef.hpp
+++ b/src/matrixTypeDef.hpp
@@ -3,78 +3,16 @@
 
 #include "fdtd.hpp"
 
-typedef vector< tuple<myint, myint, double> > BlockType;    // store rows-cols-vals of each block matrix
-
-// 0-based row-major 3-array CSR format of a matrix
-class csrFormatOfMatrix {
-public:
-    // matrix information
-    myint N_rows;
-    myint N_cols;
-    myint N_nnz;
-    myint *rows = nullptr;      // CSR row indices, size = N_rows + 1
-    myint *cols = nullptr;      // CSR col indices, size = N_nnz
-    double *vals = nullptr;      // CSR nnz values,  size = N_nnz
-
-                                 // Constructor
-    csrFormatOfMatrix(myint N_rows, myint N_cols, myint N_nnz) {
-        /* Inputs:
-        N_rows*N_cols:  matrix size;
-        N_nnz:          num of nonzeros.     */
-
-        this->N_rows = N_rows;
-        this->N_cols = N_cols;
-        this->N_nnz = N_nnz;
-
-        this->rows = new myint[N_rows + 1]();
-        this->cols = new myint[N_nnz]();
-        this->vals = new double[N_nnz]();
-    }
-
-    // Destructor
-    ~csrFormatOfMatrix() {
-        delete[] this->rows;
-        delete[] this->cols;
-        delete[] this->vals;
-    }
-
-    // Declaration of functions
-    int convertBlockTypeToCsr(const BlockType &block);
-};
-
-int csrFormatOfMatrix::convertBlockTypeToCsr(const BlockType &block) {
-    /* This function convert BlockType (COO) to CSR format.
-    The input BlockType must have been sorted by row index. */
-
-    // The first index of rows is always 0 and the last is always N_nnz
-    this->rows[0] = 0;
-    this->rows[this->N_rows] = block.size();
-
-    myint nnz_ind = 0;
-    myint thisRow_ind = 0;
-    for (const auto &nnz_tuple : block) {
-
-        // cols and vals are direct copy of the tuple for every nnz
-        this->cols[nnz_ind] = get<1>(nnz_tuple);
-        this->vals[nnz_ind] = get<2>(nnz_tuple);
-
-        // When saw nnz at a new row
-        while (thisRow_ind < get<0>(nnz_tuple)) {
-            thisRow_ind++;
-            this->rows[thisRow_ind] = nnz_ind;
-        }
-
-        nnz_ind++;
-
-        // Extrame case: when the last few rows are all blank
-        while (nnz_ind == block.size() && thisRow_ind < this->N_rows - 1) {
-            thisRow_ind++;
-            this->rows[thisRow_ind] = nnz_ind;
-        }
-    }
-
-    return 0;
-}
+// COO format
+typedef struct {
+    myint row_ind;
+    myint col_ind;
+    complex<double> val;
+}onennzType;                            // store the row-col-val of one nnz element
+typedef vector<onennzType> BlockType;   // store rows-cols-vals of all nnzs inside each block matrix
+bool ascendByRowInd(const onennzType& nnz1, const onennzType& nnz2) {
+    return nnz1.row_ind < nnz2.row_ind;
+}                                       // operator for sorting the nnz by its row_ind
 
 // 0-based column-major dense format of a matrix stored col by col in 1-D vector
 class denseFormatOfMatrix {
@@ -83,7 +21,7 @@ public:
     myint N_rows;
     myint N_cols;
     myint matrixSize;
-    vector<double> vals;
+    vector<complex<double>> vals;
 
     // Constructor
     denseFormatOfMatrix(myint N_rows, myint N_cols) {
@@ -92,16 +30,16 @@ public:
         this->matrixSize = N_rows * N_cols;
 
         this->vals.reserve(this->matrixSize);
-        this->vals.assign(this->matrixSize, 0.0);
+        this->vals.assign(this->matrixSize, { 0.0, 0.0 });
     }
 
     // Convert BlockType (COO) to dense format.
     void convertBlockTypeToDense(const BlockType &block) {
-        for (const auto &nnz_tuple : block) {
-            myint row_ind = get<0>(nnz_tuple);
-            myint col_ind = get<1>(nnz_tuple);
+        for (const auto &onennz : block) {
+            myint row_ind = onennz.row_ind;
+            myint col_ind = onennz.col_ind;
             myint ind_inArray = col_ind * this->N_rows + row_ind;
-            this->vals[ind_inArray] = get<2>(nnz_tuple);
+            this->vals[ind_inArray] = onennz.val;
         }
     }
 
@@ -151,12 +89,14 @@ public:
 
         // Use mkl cblas_?gemm (C := alpha*op(A)*op(B) + beta*C) to get C=A*B
         denseFormatOfMatrix C(this->N_rows, B.N_cols);
-        cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans,
+        complex<double> alpha(1.0, 0.0);
+        complex<double> beta(0.0, 0.0);
+        cblas_zgemm(CblasColMajor, CblasNoTrans, CblasNoTrans,
             this->N_rows, B.N_cols, this->N_cols,       // matrix dimensions ~ m, n, k
-            1.0,                                        // alpha
+            &alpha,                                     // alpha = 1
             this->vals.data(), this->N_rows,            // A
             B.vals.data(), this->N_cols,                // B
-            0.0,                                        // beta
+            &beta,                                      // beta = 0
             C.vals.data(), this->N_rows);               // C
         return C;
     }
@@ -173,9 +113,9 @@ public:
         }
 
         // Compute the LU factorization of a general m-by-n matrix A (this) and store in A_LU
-        vector<double> A_LU(this->vals);
+        vector<complex<double>> A_LU(this->vals);
         vector<myint> ipiv(this->N_rows);
-        lapack_int info = LAPACKE_dgetrf(LAPACK_COL_MAJOR,
+        lapack_int info = LAPACKE_zgetrf(LAPACK_COL_MAJOR,
             this->N_rows, this->N_cols,     // matrix dimensions ~ m, n
             A_LU.data(),                    // matrix A
             this->N_rows,
@@ -189,7 +129,7 @@ public:
         // Solve C = A_LU \ B with LAPACKE_dgetrs
         denseFormatOfMatrix C(B.N_rows, B.N_cols);
         C.vals = B.vals;                // copy matrix B to C
-        info = LAPACKE_dgetrs(LAPACK_COL_MAJOR, 'N',
+        info = LAPACKE_zgetrs(LAPACK_COL_MAJOR, 'N',
             B.N_rows, B.N_cols,         // n & nrhs
             A_LU.data(), B.N_rows,      // A_LU
             ipiv.data(),                // pivot indices of A_LU
@@ -203,5 +143,120 @@ public:
         return C;
     }
 };
+
+// 0-based row-major 3-array CSR format of a matrix
+class csrFormatOfMatrix {
+public:
+    // matrix information
+    myint N_rows;
+    myint N_cols;
+    myint N_nnz;
+    myint *rows = nullptr;                  // CSR row indices, size = N_rows + 1
+    myint *cols = nullptr;                  // CSR col indices, size = N_nnz
+    complex<double> *vals = nullptr;        // CSR nnz values,  size = N_nnz
+
+    // Constructor
+    csrFormatOfMatrix(myint N_rows, myint N_cols, myint N_nnz) {
+        /* Inputs:
+        N_rows*N_cols:  matrix size;
+        N_nnz:          num of nonzeros.     */
+
+        this->N_rows = N_rows;
+        this->N_cols = N_cols;
+        this->N_nnz = N_nnz;
+
+        this->rows = new myint[N_rows + 1]();
+        this->cols = new myint[N_nnz]();
+        this->vals = new complex<double>[N_nnz]();
+    }
+
+    // Destructor
+    ~csrFormatOfMatrix() {
+        delete[] this->rows;
+        delete[] this->cols;
+        delete[] this->vals;
+    }
+
+    // Convert BlockType (COO) to CSR
+    int convertBlockTypeToCsr(const BlockType &block);
+
+    // Return denseD0sD1s = csrB22 (this) \ denseB21B23 = inv(csrB22)*denseB21B23
+    denseFormatOfMatrix backslashDense(const denseFormatOfMatrix &denseB21B23);
+};
+
+int csrFormatOfMatrix::convertBlockTypeToCsr(const BlockType &block) {
+    /* This function convert BlockType (COO) to CSR format.
+    The input BlockType must have been sorted by row index. */
+
+    // The first index of rows is always 0 and the last is always N_nnz
+    this->rows[0] = 0;
+    this->rows[this->N_rows] = block.size();
+
+    myint nnz_ind = 0;
+    myint thisRow_ind = 0;
+    for (const auto &onennz : block) {
+
+        // cols and vals are direct copy of the tuple for every nnz
+        this->cols[nnz_ind] = onennz.col_ind;
+        this->vals[nnz_ind] = onennz.val;
+
+        // When saw nnz at a new row
+        while (thisRow_ind < onennz.row_ind) {
+            thisRow_ind++;
+            this->rows[thisRow_ind] = nnz_ind;
+        }
+
+        nnz_ind++;
+
+        // Extrame case: when the last few rows are all blank
+        while (nnz_ind == block.size() && thisRow_ind < this->N_rows - 1) {
+            thisRow_ind++;
+            this->rows[thisRow_ind] = nnz_ind;
+        }
+    }
+
+    return 0;
+}
+
+// Return denseD0sD1s = csrB22 (this) \ denseB21B23 = inv(csrB22)*denseB21B23
+denseFormatOfMatrix csrFormatOfMatrix::backslashDense(const denseFormatOfMatrix &denseB21B23) {
+
+    // combined dense [D0s, D1s]
+    denseFormatOfMatrix denseD0sD1s(denseB21B23.N_rows, denseB21B23.N_cols);
+
+    // Pardiso parameters, see https://software.intel.com/en-us/mkl-developer-reference-c-pardiso
+    MKL_INT maxfct = 1;
+    MKL_INT mnum = 1;
+    MKL_INT mtype = 13;                 /* Complex and nonsymmetric matrix */
+    MKL_INT phase = 13;
+    MKL_INT perm;
+    myint nrhs = denseB21B23.N_cols;    /* Number of right hand sides */
+    MKL_INT msglvl = 0;                 /* If msglvl=1, print statistical information */
+    MKL_INT error = 0;
+
+    void *pt[64];
+    myint iparm[64];
+    pardisoinit(pt, &mtype, iparm);
+    iparm[38] = 1;
+    iparm[34] = 1;         /* 0-based indexing */
+    iparm[3] = 0;          /* No iterative-direct algorithm */
+    //iparm[59] = 2;       /* out of core version to solve very large problem */
+    //iparm[10] = 0;       /* Use nonsymmetric permutation and scaling MPS */
+
+    pardiso(pt, &maxfct, &mnum, &mtype, &phase, &(this->N_rows), this->vals, this->rows, this->cols,
+        &perm, &nrhs, iparm, &msglvl, (complex<double>*)denseB21B23.vals.data(), denseD0sD1s.vals.data(), &error);
+    if (error != 0) {
+        printf("\nERROR during numerical factorization: %d", error);
+        exit(2);
+    }
+
+    // Release internal memory
+    phase = -1;
+    double ddum;           /* Double dummy */
+    pardiso(pt, &maxfct, &mnum, &mtype, &phase, &(this->N_rows), &ddum, this->rows, this->cols,
+        &perm, &nrhs, iparm, &msglvl, &ddum, &ddum, &error);
+
+    return denseD0sD1s;
+}
 
 #endif

--- a/src/pardisoSolver.hpp
+++ b/src/pardisoSolver.hpp
@@ -7,9 +7,114 @@
 
 #include "fdtd.hpp"
 
-using namespace std;
-
 typedef vector< tuple<myint, myint, double> > BlockType;    // store rows-cols-vals of each block matrix
+
+#define BUFF_ALIGN 64   // parameter of mkl_malloc, alignment of the buffer
+
+// 0-based row-major 3-array CSR format of a matrix
+class csrFormatOfMatrix {
+public:
+    // matrix information
+    myint N_rows;
+    myint N_cols;
+    myint N_nnz;
+    myint *rows         = nullptr;      // CSR row indices, size = N_rows + 1
+    myint *cols         = nullptr;      // CSR col indices, size = N_nnz
+    double *vals        = nullptr;      // CSR nnz values,  size = N_nnz
+
+    // Constructor
+    csrFormatOfMatrix(myint N_rows, myint N_cols, myint N_nnz) {
+        /* Inputs: 
+            N_rows*N_cols:  matrix size;
+            N_nnz:          num of nonzeros.     */
+
+        this->N_rows = N_rows;
+        this->N_cols = N_cols;
+        this->N_nnz = N_nnz;
+
+        this->rows = (myint *)mkl_malloc(sizeof(myint) * (N_rows + 1), BUFF_ALIGN);
+        this->cols = (myint *)mkl_malloc(sizeof(myint) * N_nnz, BUFF_ALIGN);
+        this->vals = (double *)mkl_malloc(sizeof(double) * N_nnz, BUFF_ALIGN);
+    }
+
+    // Destructor
+    ~csrFormatOfMatrix() {
+        mkl_free(this->rows);
+        mkl_free(this->cols);
+        mkl_free(this->vals);
+    }
+
+    // Declaration of functions
+    int convertBlockTypeToCsr(const BlockType &block);
+};
+
+int csrFormatOfMatrix::convertBlockTypeToCsr(const BlockType &block) {
+    /* This function convert BlockType (COO) to CSR format. 
+    The input BlockType must have been sorted by row index. */
+
+    // The first index of rows is always 0 and the last is always N_nnz
+    this->rows[0] = 0;
+    this->rows[this->N_rows] = block.size();
+
+    myint nnz_ind = 0;
+    myint thisRow_ind = 0;
+    for (const auto &nnz_tuple : block) {
+        
+        // cols and vals are direct copy of the tuple for every nnz
+        this->cols[nnz_ind] = get<1>(nnz_tuple);
+        this->vals[nnz_ind] = get<2>(nnz_tuple);
+
+        // When saw nnz at a new row
+        while (thisRow_ind < get<0>(nnz_tuple)) {
+            thisRow_ind++;
+            this->rows[thisRow_ind] = nnz_ind;
+        }
+
+        nnz_ind++;
+
+        // Extrame case: when the last few rows are all blank
+        while (nnz_ind == block.size() && thisRow_ind < this->N_rows-1) {
+            thisRow_ind++;
+            this->rows[thisRow_ind] = nnz_ind;
+        }
+    }
+
+    return 0;
+}
+
+// 0-based column-major dense format of a matrix stored col by col in 1-D array
+class denseFormatOfMatrix {
+public:
+    // matrix information
+    myint N_rows;
+    myint N_cols;
+    myint matrixSize;
+    double *vals = nullptr;
+
+    // Constructor
+    denseFormatOfMatrix(myint N_rows, myint N_cols) {
+        this->N_rows = N_rows;
+        this->N_cols = N_cols;
+        this->matrixSize = N_rows * N_cols;
+
+        this->vals = (double *)mkl_malloc(sizeof(double) * this->matrixSize, BUFF_ALIGN);
+    }
+
+    // Destructor
+    ~denseFormatOfMatrix() {
+        mkl_free(this->vals);
+    }
+
+    // Convert BlockType (COO) to dense format.
+    void convertBlockTypeToDense(const BlockType &block) {
+        for (const auto &nnz_tuple : block) {
+            myint row_ind = get<0>(nnz_tuple);
+            myint col_ind = get<1>(nnz_tuple);
+            myint ind_inArray = col_ind * this->N_rows + row_ind;
+            this->vals[ind_inArray] = get<2>(nnz_tuple);
+        }
+    }
+};
 
 vector<myint> Map_eInd_GrowZ2Y(const myint Nx, const myint Ny, const myint Nz) {
     /* This function changes the global {e} index from layer growth along Z to that along Y.
@@ -95,10 +200,10 @@ vector<myint> Reverse_Map_eInd(const vector<myint> &eInd_map_z2y) {
 }
 
 // Map specific Block_rowId and Block_colId to an unique Block index
-inline myint Map_RowCol_2BlockId(const myint B_rowId, const myint B_colId) {
+inline myint mapRowColIdToBlockId(const myint B_rowId, const myint B_colId) {
     /* Explanation to notations here:
 
-    Matrix S is partitioned into blocks as surface-vlo-surface-... along row/col
+    Matrix S is partitioned into blocks as surface-vol-surface-... along row/col
     Bolck ordering:     0s,0v,1s,1v,..., Nlayer_s
     Block row/col Id:   0, 1, 2, 3, ..., 2*Nlayer
     BlockId:            counted nnz block Id, row major. 
@@ -135,31 +240,168 @@ inline myint Map_RowCol_2BlockId(const myint B_rowId, const myint B_colId) {
     return BlockId;
 }
 
-void EliminateVolumE(const vector<BlockType> &layerS) {
-    /* This function eliminates e_vol from whole S matrix (all layers coupled) and obtain the
-    2*2 block matrix regarding the coupled e_surf at an isolated layer.
+// Solve D0sD1s = inv(B22)*B21B23 in Pardiso
+int solveInverseInPardiso(const csrFormatOfMatrix &csrB22, 
+    const denseFormatOfMatrix &denseB21B23, denseFormatOfMatrix *pdenseD0sD1s) {
 
-    Input:
+    // Pardiso parameters, see https://software.intel.com/en-us/mkl-developer-reference-c-pardiso
+    MKL_INT maxfct = 1;
+    MKL_INT mnum = 1;
+    MKL_INT mtype = 11;                 /* Real unsymmetric matrix */
+    MKL_INT phase = 13;
+    MKL_INT perm;
+    myint nrhs = denseB21B23.N_cols;    /* Number of right hand sides */
+    MKL_INT msglvl = 0;                 /* If msglvl=1, print statistical information */
+    MKL_INT error = 0;
+
+    void *pt[64];
+    myint iparm[64];
+    pardisoinit(pt, &mtype, iparm);
+    iparm[38] = 1;
+    iparm[34] = 1;         /* 0-based indexing */
+    iparm[3] = 0;          /* No iterative-direct algorithm */
+    //iparm[59] = 2;       /* out of core version to solve very large problem */
+    //iparm[10] = 0;       /* Use nonsymmetric permutation and scaling MPS */
+
+    pardiso(pt, &maxfct, &mnum, &mtype, &phase, &(csrB22.N_rows), csrB22.vals, csrB22.rows, csrB22.cols,
+        &perm, &nrhs, iparm, &msglvl, denseB21B23.vals, pdenseD0sD1s->vals, &error);
+    if (error != 0) {
+        printf("\nERROR during numerical factorization: %d", error);
+        exit(2);
+    }
+
+    // Release internal memory
+    phase = -1;
+    double ddum;           /* Double dummy */
+    pardiso(pt, &maxfct, &mnum, &mtype, &phase, &(csrB22.N_rows), &ddum, csrB22.rows, csrB22.cols,
+        &perm, &nrhs, iparm, &msglvl, &ddum, &ddum, &error);
+
+    return 0;
+}
+
+// Compute y = alpha * A * x + beta * y and store computed dense matrix in y
+int csrMultiplyDense(const sparse_matrix_t &csrA_mklHandle,     // mkl handle of csr A
+                        myint N_rows_x, double *x,              // x,y ~ dense matrix stored in array 
+                        denseFormatOfMatrix *y) {
+    /* see doc: https://software.intel.com/en-us/onemkl-developer-reference-c-mkl-sparse-mm
+    Example: 
+            y   = alpha * A   * x   + beta * y
+            C11 = -1.0  * B12 * D0s + 1.0  * B11    */
+
+
+    double alpha = -1.0, beta = 1.0;
+    struct matrix_descr descrA;             // Descriptor of main sparse matrix properties
+    descrA.type = SPARSE_MATRIX_TYPE_GENERAL;
+
+    // Compute y = alpha * A * x + beta * y
+    mkl_sparse_d_mm(SPARSE_OPERATION_NON_TRANSPOSE,
+        alpha,
+        csrA_mklHandle,
+        descrA,
+        SPARSE_LAYOUT_COLUMN_MAJOR,         // Describes the storage scheme for the dense matrix
+        x,
+        y->N_cols,
+        N_rows_x,
+        beta,
+        y->vals,
+        y->N_rows);
+
+    return 0;
+}
+
+void eliminateVolumE(const vector<BlockType> &layerS, myint N_surfE, myint N_volE) {
+    /* This function eliminates e_vol from whole S matrix (all layers coupled) and obtain the
+    2*2 block matrix related only to e_surf at single layer.
+
+    Inputs:
         layerS: a vector containing 9 blocks of the whole matrix S, ~ within one layer
+        N_surfE: number of {e}_surface at one surface, e.g. 0s
+        N_volE: number of {e}_volumn at one layer, e.g. 0v
     Output:
         reducedS: 
 
     Each isolated layer here contains 2 surfaces and 1 middle volumn e, namely 0s-0v-1s. 
-    A symbolic form is (each number represents a block matrix):
+    A symbolic form is (each number represents the blockId in vector<BlockType>):
                 
                  0s  0v  1s                                    0s  1s
     layerS =   | 0   1   2 |    0s      ==>     reducedS =   | 0'  1'|    0s
                | 3   4   5 |    0v                           | 2'  3'|    1s
                | 6   7   8 |    1s
-    Notes:
-    1)  9 blocks of the input layerS is directly truncated from system matrix S, so block 0 and block 9 
-        might be double counted compared to isolated single-layer S.
-    2)  PEC BCs on top or bottom (z-direction) will be considered here
+    
+    corresponding to block variable names in this function:
+                 0s  0v  1s                                    0s  1s
+    layerS ~   | B11 B12 B13 |  0s      ==>     reducedS ~   | C11 C12 |  0s
+               | B21 B22 B23 |  0v                           | C21 C22 |  1s
+               | B31 B32 B33 |  1s
+    
+    Due to the structure of matrix S, the central row of layerS is full, which could 
+    be used to eliminate e0v as:  
+        B21*e0s+B22*e0v+B23*e1s = 0  =>  e0v = -D0s*e0s - D1s*e1s, 
+        where 
+            D0s = inv(B22)*B21, D1s = inv(B22)*B23.
+        Then the relation is: 
+            C11 = B11 - B12*D0s,    C12 = B13 - B12*D1s
+            C21 = B31 - B32*D0s,    C22 = B33 - B32*D1s
     */
     
+    // Combine B21 and B23 in order to be sloved in one Pardiso run.
+    BlockType vB21B23(layerS[3]);
+    move(layerS[5].begin(), layerS[5].end(), back_inserter(vB21B23));
+    denseFormatOfMatrix denseB21B23(N_volE, 2 * N_surfE);       // combined dense [B21, B23]
+    denseB21B23.convertBlockTypeToDense(vB21B23);
+    vB21B23.clear();
+
+    // Solve D0s = inv(B22)*B21, D1s = inv(B22)*B23 in Pardiso
+    csrFormatOfMatrix csrB22(N_volE, N_volE, layerS[4].size());
+    csrB22.convertBlockTypeToCsr(layerS[4]);
+    denseFormatOfMatrix denseD0sD1s(N_volE, 2 * N_surfE);       // combined dense [D0s, D1s]
+
+    solveInverseInPardiso(csrB22, denseB21B23, &denseD0sD1s);
+    csrB22.~csrFormatOfMatrix();                                // free CSR B22
+    denseB21B23.~denseFormatOfMatrix();                         // free combined dense [B21, B23]
+
+    // Convert B12, B32 to mkl internal CSR matrix handles
+    sparse_matrix_t csrB12_mklHandle, csrB32_mklHandle;
+
+    csrFormatOfMatrix csrB12(N_surfE, N_volE, layerS[1].size());
+    csrB12.convertBlockTypeToCsr(layerS[1]);
+    mkl_sparse_d_create_csr(&csrB12_mklHandle, SPARSE_INDEX_BASE_ZERO, csrB12.N_rows, csrB12.N_cols,
+        csrB12.rows, csrB12.rows + 1, csrB12.cols, csrB12.vals);
+    csrB12.~csrFormatOfMatrix();                                // free CSR B12
+
+    csrFormatOfMatrix csrB32(N_surfE, N_volE, layerS[7].size());
+    csrB32.convertBlockTypeToCsr(layerS[7]);
+    mkl_sparse_d_create_csr(&csrB32_mklHandle, SPARSE_INDEX_BASE_ZERO, csrB32.N_rows, csrB32.N_cols,
+        csrB32.rows, csrB32.rows + 1, csrB32.cols, csrB32.vals);
+    csrB32.~csrFormatOfMatrix();                                // free CSR B32
+
+    // Solve reducedS blocks C11 = B11 - B12*D0s, C12 = B13 - B12*D1s
+    denseFormatOfMatrix denseB11(N_surfE, N_surfE);
+    denseB11.convertBlockTypeToDense(layerS[0]);
+    csrMultiplyDense(csrB12_mklHandle, denseD0sD1s.N_rows, denseD0sD1s.vals, &denseB11);
+
+    myint matrixSizeD0s = N_volE * N_surfE;
+    denseFormatOfMatrix denseB13(N_surfE, N_surfE);
+    denseB13.convertBlockTypeToDense(layerS[2]);
+    csrMultiplyDense(csrB12_mklHandle, denseD0sD1s.N_rows, denseD0sD1s.vals + matrixSizeD0s, &denseB13);
+
+    mkl_sparse_destroy(csrB12_mklHandle);                       // free mkl CSR B12 handle
+
+    // Solve reducedS blocks C21 = B31 - B32*D0s, C22 = B33 - B32*D1s
+    denseFormatOfMatrix denseB31(N_surfE, N_surfE);
+    denseB31.convertBlockTypeToDense(layerS[6]);
+    csrMultiplyDense(csrB32_mklHandle, denseD0sD1s.N_rows, denseD0sD1s.vals, &denseB31);
+
+    denseFormatOfMatrix denseB33(N_surfE, N_surfE);
+    denseB33.convertBlockTypeToDense(layerS[8]);
+    csrMultiplyDense(csrB32_mklHandle, denseD0sD1s.N_rows, denseD0sD1s.vals + matrixSizeD0s, &denseB33);
+
+    mkl_sparse_destroy(csrB32_mklHandle);                       // free mkl CSR B32 handle
+
+    denseD0sD1s.~denseFormatOfMatrix();                         // free combined dense [D0s, D1s]
 }
 
-void Cascade_matrixS(fdtdMesh *psys) {
+void cascadeMatrixS(fdtdMesh *psys) {
 
     // Num of e at each surface or each layer. Layer growth along y.
     myint Nx                    = psys->N_cell_x;
@@ -167,9 +409,10 @@ void Cascade_matrixS(fdtdMesh *psys) {
     myint n_surfExEz            = Nx*(Nz + 1) + Nz*(Nx + 1);
     myint n_volEy               = (Nx + 1)*(Nz + 1);
     myint n_layerE_growY        = n_surfExEz + n_volEy;
+    myint N_layers              = psys->N_cell_y;   // num of layers
 
     // Store all Bolck matrices in a vector (2-D vector)
-    vector< BlockType > Blocks(8* psys->N_cell_y + 1);
+    vector< BlockType > Blocks(8 * N_layers + 1);
 
     // Determine the block id of each nnz element of S and store in corresponding block matrix
     myint nnzS_rowId, nnzS_colId, B_rowId, B_colId, BlockId;
@@ -180,7 +423,11 @@ void Cascade_matrixS(fdtdMesh *psys) {
         B_rowId = nnzS_rowId / n_layerE_growY * 2 + (nnzS_rowId % n_layerE_growY) / n_surfExEz;
         B_colId = nnzS_colId / n_layerE_growY * 2 + (nnzS_colId % n_layerE_growY) / n_surfExEz;
 
-        BlockId = Map_RowCol_2BlockId(B_rowId, B_colId);
+        BlockId = mapRowColIdToBlockId(B_rowId, B_colId);
+
+        // Shift the start row index and col index to be 0 inside each block
+        nnzS_rowId = nnzS_rowId - (B_rowId / 2) * n_layerE_growY - (B_rowId % 2) * n_surfExEz;
+        nnzS_colId = nnzS_colId - (B_colId / 2) * n_layerE_growY - (B_colId % 2) * n_surfExEz;
 
         Blocks[BlockId].push_back(make_tuple(nnzS_rowId, nnzS_colId, psys->Sval[i_nnz]));
     }
@@ -190,16 +437,41 @@ void Cascade_matrixS(fdtdMesh *psys) {
     free(psys->SColId);
     free(psys->Sval);
 
+    /******************** Start Cascading Matrix S from Blocks ***************************/
+    
+    // Consider PEC BCs on top or bottom (zmin & zmax) here
+    // To be done!
+
+    // Tell the size of sparse block matrices 
+    myint N_surfE = n_surfExEz;
+    myint N_volE = n_volEy;
+
+    // Sort each block matrix by its row indices, 1st element of the tuple
+    /* The purpose is to allow easy convert from COO to CSR format*/
+    for (auto &block : Blocks) {
+        sort(block.begin(), block.end());
+    }
+
+    // Half the value of overlapped ns-ns blocks between adjcent two layers
+    /* The partitioned blocks no longer mean physical curl-curl opeartor, but mamatically, this is doable to
+    cascade block matrix S. Any partition works like C = aC' + bC''. C = C' + C' makes codeing easier.*/
+    for (myint nsns_BlockId = 8; nsns_BlockId < 8 * N_layers; nsns_BlockId += 8) {
+        for (auto &nnz : Blocks[nsns_BlockId]) {
+            get<2>(nnz) *= 0.5;
+        }
+    }
+
     // Eliminate e_volumn at each layer
-    myint N_layers = psys->N_cell_y;
     for (myint i_layer = 0; i_layer < N_layers; i_layer++) {
         
-        vector< BlockType > layerS(Blocks.begin() + 8* i_layer, Blocks.begin() + 8 * i_layer + 9);
-        EliminateVolumE(layerS);
+        vector<BlockType> layerS(Blocks.begin() + 8* i_layer, Blocks.begin() + 8 * i_layer + 9);
+        eliminateVolumE(layerS, N_surfE, N_volE);
 
         layerS.clear();
     }
-    Blocks.clear();     // free blocks in matrix S to save memory
+
+    // free blocks of original whole matrix S to save memory
+    Blocks.clear();
 
 }
 
@@ -238,7 +510,7 @@ void Assign_J_eachPort(fdtdMesh *psys, int sourcePort) {
 // Solve E field and Z-parameters in Pardiso, solve layer by layer. (under developing)
 void Solve_E_Zpara_InPardiso_layered(fdtdMesh *psys) {
 
-    Cascade_matrixS(psys);
+    cascadeMatrixS(psys);
 
     // All computed freq points
     vector<double> vFreqHz = CalAllFreqPointsHz(*psys);

--- a/src/pardisoSolver.hpp
+++ b/src/pardisoSolver.hpp
@@ -515,13 +515,12 @@ denseFormatOfMatrix reconstruct_e(fdtdMesh *psys, const mapIndex &indexMap, cons
             // For original noncascaded index, mode (growZ, removed PEC)
             myint surfInd_thisPort = surfLocationOfPort[ind_thisPort];
             myint shift_surfvol = surfInd_thisPort * (N_surfExEz + n_volEy);    // index shift from all surf-vol {e} before this surface
-            myint eInd_growY = e_ind + shift_surfvol;                           // Step 1: -> index at (growY, no PEC removal)
+            myint eInd_growYrmPEC = e_ind + shift_surfvol;                      // Step 0: -> index at (growY, removed PEC)
+            myint eInd_growY = indexMap.eInd_map_rmPEC2y[eInd_growYrmPEC];      // Step 1: -> index at (growY, no PEC removal)
             myint eInd_growZ = indexMap.eInd_map_y2z[eInd_growY];               // Step 2: map (growY, no PEC removal) to (growZ, no PEC removal)
             myint eInd_growZrmPEC = psys->mapEdge[eInd_growZ];                  // Step 3: map (growZ, no PEC removal) to (growZ, removed PEC)
             
-            if (eInd_growZrmPEC != -1) {
-                eField_oneExcit.vals[eInd_growZrmPEC] = cascadedeField_SI.vals[eInd_cascaded];
-            }   // psys->mapEdge maps PEC edge index to -1, meaning not in domain
+            eField_oneExcit.vals[eInd_growZrmPEC] = cascadedeField_SI.vals[eInd_cascaded];
         }
     }
 


### PR DESCRIPTION
The merge contains the first workable version of layeredFD solver.

The layeredFD solver did the following steps:
1) Convert the whole system matrix S to smaller S at each layer (with new layer growth direction along y);
2) Cascade the S matrix by eliminating both volume {e} and surface {e} not a t the port surfaces;
3) Cascade the excitation current and solve the cascaded system;
4) Reconstruct the {e} to original size and reuse the code in V0Vh solver to generate Z-parameters.

The solver has been tested on singleStrip example and has shown fairly good performance. Right now, all matrix operations in the layeredFD solver are done with MKL.